### PR TITLE
Update translation in client.es.yml

### DIFF
--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -13,7 +13,7 @@ es:
         insert_button: "Crear respuesta"
         new_button: "Nuevo"
         edit_button: "Editar"
-        modal_title: "Crear nueva respuesta enlatada"
+        modal_title: "Seleccionar o crear nueva respuesta enlatada"
         sort:
           alphabetically: "Ordenar alfabéticamente"
           usage: "Ordenar por frecuencia de uso"


### PR DESCRIPTION
When modal popup, the message is incorrect. 
Now it's correct. (In spanish)