### PR TITLE
Changed UI.

### DIFF
--- a/assets/javascripts/discourse/components/canned-reply.js.es6
+++ b/assets/javascripts/discourse/components/canned-reply.js.es6
@@ -1,0 +1,71 @@
+import showModal from 'discourse/lib/show-modal';
+import { ajax } from 'discourse/lib/ajax';
+import { popupAjaxError } from 'discourse/lib/ajax-error';
+
+export default Ember.Component.extend({
+
+  /**
+   * Whether the content is shown or the excerpt.
+   *
+   * @type {Boolean}
+   */
+  isOpen: false,
+
+  actions: {
+
+    /**
+     * Opens the content and hides the excerpt.
+     */
+    open: function() {
+      this.set('isOpen', true);
+    },
+
+    /**
+     * Hides the content and shows the excerpt.
+     */
+    close: function() {
+      this.set('isOpen', false);
+    },
+
+    /**
+     * Applies the canned reply.
+     */
+    apply: function() {
+      // TODO: This is ugly. There _must_ be another way.
+      // TODO: This code is also duplicated (see controller).
+      const composer = Discourse.__container__.lookup('controller:composer');
+
+      if (composer.model) {
+        const newReply = composer.model.get('reply') + this.get('reply.content');
+        composer.model.set('reply', newReply);
+        if (!composer.model.get('title')) {
+          composer.model.set('title', this.get('reply.title'));
+        }
+      }
+
+      ajax(`/canned_replies/${this.get('reply.id')}/use`, {
+        type: "PATCH"
+      }).catch(popupAjaxError);
+
+      this.appEvents.trigger('canned-replies:hide');
+    },
+
+    /**
+     * Shows model used for editing current reply.
+     */
+    editReply: function () {
+      // TODO: This is ugly. There _must_ be another way.
+      // TODO: This code is also duplicated (see controller).
+      const composer = Discourse.__container__.lookup('controller:composer');
+
+      composer.send('closeModal');
+      showModal('edit-reply').setProperties({
+        composerModel: composer.composerModel,
+        replyId: this.get('reply.id'),
+        replyTitle: this.get('reply.title'),
+        replyContent: this.get('reply.content')
+      });
+    }
+  }
+
+});

--- a/assets/javascripts/discourse/connectors/editor-preview/canned-replies.js.es6
+++ b/assets/javascripts/discourse/connectors/editor-preview/canned-replies.js.es6
@@ -1,0 +1,60 @@
+import showModal from 'discourse/lib/show-modal';
+import { ajax } from 'discourse/lib/ajax';
+import { i18n } from 'discourse/lib/computed';
+import { popupAjaxError } from 'discourse/lib/ajax-error';
+
+export default {
+
+  setupComponent(args, component) {
+    component.set('isVisible', false);
+    component.set('loadingReplies', false);
+    component.set('replies', []);
+    component.set('filterHint', i18n('canned_replies.filter_hint'));
+
+    component.appEvents.on('canned-replies:show', () => {
+      component.send('show');
+    });
+
+    component.appEvents.on('canned-replies:hide', () => {
+      component.send('hide');
+    });
+
+    component.addObserver('listFilter', function () {
+      const filterTitle = component.get('listFilter').toLowerCase();
+
+      component.set('loadingReplies', true);
+      ajax("/canned_replies").then(results => {
+        component.set("replies", results.replies.filter(function (reply) {
+          return reply.title.toLowerCase().indexOf(filterTitle) !== -1;
+        }));
+      }).catch(popupAjaxError).finally(() => component.set('loadingReplies', false));
+    });
+  },
+
+  actions: {
+    show() {
+      // TODO: Move this line somewhere else where other plugins can use it too?
+      $(".d-editor-cooked").hide();
+      this.set('isVisible', true);
+
+      this.set('loadingReplies', true);
+      ajax("/canned_replies").then(results => {
+        this.set("replies", results.replies);
+      }).catch(popupAjaxError).finally(() => this.set('loadingReplies', false));
+    },
+
+    hide() {
+      // TODO: Move this line somewhere else where other plugins can use it too?
+      $(".d-editor-cooked").show();
+      this.set('isVisible', false);
+    },
+
+    newReply() {
+      // TODO: This is ugly. There _must_ be another way.
+      const composerController = Discourse.__container__.lookup('controller:composer');
+      composerController.send('closeModal');
+      showModal('new-reply').setProperties({ newContent: composerController.model.reply });
+    }
+  }
+
+};

--- a/assets/javascripts/discourse/controllers/canned-replies.js.es6
+++ b/assets/javascripts/discourse/controllers/canned-replies.js.es6
@@ -3,7 +3,6 @@ import showModal from 'discourse/lib/show-modal';
 import { ajax } from 'discourse/lib/ajax';
 import { default as computed, observes } from 'ember-addons/ember-computed-decorators';
 import { popupAjaxError } from 'discourse/lib/ajax-error';
-import { cook } from 'discourse/lib/text';
 
 export default Ember.Controller.extend(ModalFunctionality, {
   selectedReply: null,
@@ -18,11 +17,6 @@ export default Ember.Controller.extend(ModalFunctionality, {
   @observes("selectedReplyID")
   _updateSelection() {
     this.selectionChange();
-  },
-
-  @computed('selectedReply.content')
-  selectedReplyCookedContent(content) {
-    return cook(content);
   },
 
   getReplyByID(id) {

--- a/assets/javascripts/discourse/initializers/add-canned-replies-ui-builder.js.es6
+++ b/assets/javascripts/discourse/initializers/add-canned-replies-ui-builder.js.es6
@@ -6,7 +6,11 @@ function initializeCannedRepliesUIBuilder(api) {
   ComposerController.reopen({
     actions: {
       showCannedRepliesButton: function () {
-        showModal('canned-replies').setProperties({ composerModel: this.model });
+        if (this.site.mobileView) {
+          showModal('canned-replies').setProperties({ composerModel: this.model });
+        } else {
+          this.appEvents.trigger('canned-replies:show');
+        }
       }
     }
   });

--- a/assets/javascripts/discourse/templates/components/canned-reply.hbs
+++ b/assets/javascripts/discourse/templates/components/canned-reply.hbs
@@ -1,0 +1,27 @@
+<div class="canned-reply">
+
+  <p class="canned-reply-title">
+    {{d-button class="btn-primary canned-replies-apply"
+      action="apply"
+      icon="clipboard"}}
+
+    {{d-button class="btn canned-replies-edit"
+        action="editReply"
+        icon="pencil"}}
+
+    {{reply.title}}
+
+    {{#if isOpen}}
+      <a class="pull-right" {{action "close"}}>{{fa-icon "chevron-up"}}</a>
+    {{else}}
+      <a class="pull-right" {{action "open"}}>{{fa-icon "chevron-down"}}</a>
+    {{/if}}
+  </p>
+
+  {{#if isOpen}}
+    {{{cook-text reply.content}}}
+  {{else}}
+    {{{cook-text reply.excerpt}}}
+  {{/if}}
+
+</div>

--- a/assets/javascripts/discourse/templates/connectors/editor-preview/canned-replies.hbs
+++ b/assets/javascripts/discourse/templates/connectors/editor-preview/canned-replies.hbs
@@ -1,0 +1,13 @@
+{{#if isVisible}}
+  {{#conditional-loading-spinner condition=loadingReplies}}
+    {{d-button class="btn canned-replies-new"
+        action="newReply"
+        icon="plus"
+        label="canned_replies.insert.new_button"}}
+    {{text-field value=listFilter placeholder=filterHint}}
+    <a class="close pull-right" {{action "hide"}}>{{fa-icon "times"}}</a>
+    {{#each replies as |r|}}
+      {{canned-reply reply=r}}
+    {{/each}}
+  {{/conditional-loading-spinner}}
+{{/if}}

--- a/assets/javascripts/discourse/templates/modal/canned-replies.hbs
+++ b/assets/javascripts/discourse/templates/modal/canned-replies.hbs
@@ -18,7 +18,7 @@
       {{#if selectedReply}}
         <div class="content">
           <div>
-            {{selectedReplyCookedContent}}
+            {{{cook-text selectedReply.content}}}
           </div>
         </div>
       {{/if}}

--- a/assets/stylesheets/canned-replies.scss
+++ b/assets/stylesheets/canned-replies.scss
@@ -19,3 +19,16 @@
 .mobile-view .canned-replies-modal .d-editor-preview-wrapper {
   display: none;
 }
+
+.canned-replies-footer {
+  margin-top: 3px;
+}
+
+.canned-reply {
+  border-bottom: 1px solid dark-light-diff($primary, $secondary, 90%, -60%);
+
+  .canned-reply-title {
+    font-weight: bold;
+    padding: 3px 0px;
+  }
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,6 +1,7 @@
 en:
   js:
     canned_replies:
+      filter_hint: 'title...'
       composer_button_text: "Canned replies"
       title:
         name: 'Title'

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -6,6 +6,6 @@ en:
       title: "My first canned reply"
       body: |
         This is an example canned reply.
-        You can user **markdown** to style your replies. Click the **new** button to create new replies or the **edit** button to edit or remove an existing canned reply.
+        You can use **markdown** to style your replies. Click the **new** button to create new replies or the **edit** button to edit or remove an existing canned reply.
 
         *This canned reply will be added when the replies list is empty.*

--- a/plugin.rb
+++ b/plugin.rb
@@ -57,12 +57,16 @@ after_initialize do
 
         return [] if replies.blank?
 
-        #sort by usages
-        replies.values.sort_by { |reply| reply['usages'] || 0 }.reverse!
+        replies.each do |id, reply|
+          cooked = PrettyText.cook(reply[:content])
+          reply[:excerpt] = PrettyText.excerpt(cooked, 100) if cooked
+        end
+
+        replies.values.sort_by { |reply| reply['title'] || '' }
       end
 
       def get_reply(user_id, reply_id)
-        replies = PluginStore.get(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME)
+        replies = all(user_id)
         replies[reply_id]
       end
 


### PR DESCRIPTION
TODO:
- [ ] remove duplicated code (there is a lot of it because the old UI is still here for mobile view)
- [ ] figure out a way to remove ugly constructs (e.g. `Discourse.__container__`) - I could not find a better way to access resources I needed
- [ ] decide on placement of canned replies button (to be left in options menu or moved to toolbar, the latter makes it easier to access)

Works with nbianca/discourse@81dc1f039d39bdeb288941e2deb4fb0c2a108974.