### PR TITLE
Added Travis configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ install:
   - bundle install --without development --deployment --retry=3 --jobs=3
 
 script:
-  - bash -c "if [ '$QUNIT_RUN' == '0' ]; then bundle exec rake plugin:spec; else bundle exec rake qunit:test FILTER='$PLUGIN_NAME'; fi"
+  - bash -c "if [ '$QUNIT_RUN' == '0' ]; then LOAD_PLUGINS=1 bundle exec rake plugin:spec; else bundle exec rake qunit:test FILTER='$PLUGIN_NAME'; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,51 @@
+language: ruby
+
+env:
+  global:
+    - DISCOURSE_HOSTNAME=www.example.com
+    - RUBY_GC_MALLOC_LIMIT=50000000
+  matrix:
+    - "RAILS_MASTER=0"
+    - "RAILS_MASTER=1"
+
+addons:
+  postgresql: 9.5
+  apt:
+    packages:
+    - gifsicle
+    - jpegoptim
+    - optipng
+    - jhead
+
+matrix:
+  allow_failures:
+    - env: "RAILS_MASTER=1"
+  fast_finish: true
+
+rvm:
+  - 2.4.1
+  - 2.3.3
+
+services:
+  - redis-server
+
+sudo: required
+dist: trusty
+cache: yarn
+
+before_install:
+  - git clone --depth=1 https://github.com/discourse/discourse.git build ; cd build ; rm -rf plugins/*
+  - gem install bundler
+  - git clone --depth=1 https://github.com/discourse/discourse-canned-replies.git plugins/discourse-canned-replies
+  - yarn global add eslint babel-eslint
+  - eslint --ext .es6 plugins/**/assets/javascripts
+
+before_script:
+  - bundle exec rake db:create db:migrate
+
+install:
+  - bash -c "if [ '$RAILS_MASTER' == '1' ]; then bundle update --retry=3 --jobs=3 arel rails seed-fu; fi"
+  - bash -c "if [ '$RAILS_MASTER' == '0' ]; then bundle install --without development --deployment --retry=3 --jobs=3; fi"
+
+script:
+  - bundle exec rake plugin:spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ env:
   global:
     - DISCOURSE_HOSTNAME=www.example.com
     - RUBY_GC_MALLOC_LIMIT=50000000
+    - PLUGIN_NAME='Canned Replies'
   matrix:
-    - "RAILS_MASTER=0"
-    - "RAILS_MASTER=1"
+    - QUNIT_RUN=0
+    - QUNIT_RUN=1
 
 addons:
   postgresql: 9.5
@@ -16,11 +17,6 @@ addons:
     - jpegoptim
     - optipng
     - jhead
-
-matrix:
-  allow_failures:
-    - env: "RAILS_MASTER=1"
-  fast_finish: true
 
 rvm:
   - 2.4.1
@@ -36,7 +32,7 @@ cache: yarn
 before_install:
   - git clone --depth=1 https://github.com/discourse/discourse.git build ; cd build ; rm -rf plugins/*
   - gem install bundler
-  - git clone --depth=1 https://github.com/discourse/discourse-canned-replies.git plugins/discourse-canned-replies
+  - git clone --depth=1 -b $TRAVIS_BRANCH https://github.com/$TRAVIS_REPO_SLUG.git plugins/discourse-canned-replies
   - yarn global add eslint babel-eslint
   - eslint --ext .es6 plugins/**/assets/javascripts
 
@@ -44,8 +40,7 @@ before_script:
   - bundle exec rake db:create db:migrate
 
 install:
-  - bash -c "if [ '$RAILS_MASTER' == '1' ]; then bundle update --retry=3 --jobs=3 arel rails seed-fu; fi"
-  - bash -c "if [ '$RAILS_MASTER' == '0' ]; then bundle install --without development --deployment --retry=3 --jobs=3; fi"
+  - bundle install --without development --deployment --retry=3 --jobs=3
 
 script:
-  - bundle exec rake plugin:spec
+  - bash -c "if [ '$QUNIT_RUN' == '0' ]; then bundle exec rake plugin:spec; else bundle exec rake qunit:test FILTER='$PLUGIN_NAME'; fi"


### PR DESCRIPTION
This Travis configuration should pull Discourse's code and run tests for plugins.

For a smaller footprint, all plugins that are bundled with Discourse are removed and only the relevant plugins (in this case, discourse-canned-replies) is pulled and tested.

It's a quite hacky solution, as there is no Travis config variable to set where the code should be pulled (i.e. directly to the `plugins` folder).

[Examples](https://travis-ci.org/nbianca/discourse-canned-replies/branches) of jobs. Please, take into consideration only the jobs for the `travis` branch, because it is the only branch that actually has the configuration.