### PR TITLE
Moved button to toolbar.

### DIFF
--- a/assets/javascripts/discourse/initializers/add-canned-replies-ui-builder.js.es6
+++ b/assets/javascripts/discourse/initializers/add-canned-replies-ui-builder.js.es6
@@ -3,26 +3,22 @@ import showModal from 'discourse/lib/show-modal';
 import ComposerController from 'discourse/controllers/composer';
 
 function initializeCannedRepliesUIBuilder(api) {
-  ComposerController.reopen({
-    actions: {
-      showCannedRepliesButton: function () {
-        if (this.site.mobileView) {
-          showModal('canned-replies').setProperties({ composerModel: this.model });
+  api.onToolbarCreate(toolbar => {
+    toolbar.addButton({
+      id: 'canned_replies_button',
+      group: 'extras',
+      icon: 'clipboard',
+      action: function () {
+        const controller = Discourse.__container__.lookup('controller:composer');
+        if (controller.site.mobileView) {
+          showModal('canned-replies').setProperties({ composerModel: controller.model });
         } else {
-          this.appEvents.trigger('composer:show-preview');
-          this.appEvents.trigger('canned-replies:show');
+          controller.appEvents.trigger('composer:show-preview');
+          controller.appEvents.trigger('canned-replies:show');
         }
-      }
-    }
-  });
-
-  api.addToolbarPopupMenuOptionsCallback(function () {
-    return {
-      id: "canned_replies_button",
-      icon: "clipboard",
-      action: 'showCannedRepliesButton',
-      label: 'canned_replies.composer_button_text'
-    };
+      },
+      title: 'canned_replies.composer_button_text'
+    });
   });
 }
 
@@ -36,5 +32,5 @@ export default {
     if (siteSettings.canned_replies_enabled && currentUser && currentUser.staff) {
       withPluginApi('0.5', initializeCannedRepliesUIBuilder);
     }
-  }
+  },
 };


### PR DESCRIPTION
Promotes the canned replies plugin to 1st class citizen (as requested on Meta). :star: