### PR TITLE
FIX: apply changes to canned replies after edit

### DIFF
--- a/assets/javascripts/discourse/connectors/editor-preview/canned-replies.js.es6
+++ b/assets/javascripts/discourse/connectors/editor-preview/canned-replies.js.es6
@@ -58,7 +58,7 @@ export default {
 
   actions: {
     show() {
-      $(".d-editor-preview-wrapper > .d-editor-preview").hide();
+      $("#reply-control .d-editor-preview-wrapper > .d-editor-preview").hide();
       this.set('isVisible', true);
       this.set('loadingReplies', true);
 

--- a/assets/javascripts/discourse/controllers/edit-reply.js.es6
+++ b/assets/javascripts/discourse/controllers/edit-reply.js.es6
@@ -28,7 +28,10 @@ export default Ember.Controller.extend(ModalFunctionality, {
       ajax(`/canned_replies/${this.get('replyId')}`, {
         type: "PATCH",
         data: { title: this.get('replyTitle'), content: this.get('replyContent') }
-      }).catch(popupAjaxError).finally(() => this.set('saving', false));
+      }).catch(popupAjaxError).finally(() => {
+        this.set('saving', false);
+        this.appEvents.trigger('canned-replies:show');
+      });
     },
 
     remove() {


### PR DESCRIPTION
https://meta.discourse.org/t/editing-canned-replies-needs-reload-to-apply-changes/76035