### PR TITLE
Fix "Canned replies should require titles to be unique"

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -29,11 +29,13 @@ after_initialize do
 
         replies = PluginStore.get(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME)
         titleAlreadyUsed = false
-        replies.each do
-          |reply|
-          if (reply[1]["title"] == title)
-            titleAlreadyUsed = true
-            break
+        if replies
+          replies.each do
+            |reply|
+            if (reply[1]["title"] == title)
+              titleAlreadyUsed = true
+              break
+            end
           end
         end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -118,11 +118,7 @@ after_initialize do
 
       record = CannedReply::Reply.add(user_id, title, content)
 
-      if (record[:status] == 500)
-          render json: record, status: 500
-      else
-          render json: record
-      end
+      render json: record, status: record[:status]
     end
 
     def destroy

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: discourse-canned-replies
 # about: Add canned replies through the composer
-# version: 1.2
+# version: 1.3
 # authors: Jay Pfaffman and André Pereira
 # url: https://github.com/discourse/discourse-canned-replies
 
@@ -26,15 +26,30 @@ after_initialize do
     class << self
 
       def add(user_id, title, content)
-        id = SecureRandom.hex(16)
-        record = { id: id, title: title, content: content }
 
-        replies = PluginStore.get(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME) || {}
+        replies = PluginStore.get(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME)
+        titleAlreadyUsed = false
+        replies.each do
+          |reply|
+          if (reply[1]["title"] == title)
+            titleAlreadyUsed = true
+            break
+          end
+        end
 
-        replies[id] = record
-        PluginStore.set(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME, replies)
+        if (titleAlreadyUsed == false)
+          id = SecureRandom.hex(16)
+          record = { id: id, title: title, content: content }
 
-        record
+          replies = PluginStore.get(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME) || {}
+
+          replies[id] = record
+          PluginStore.set(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME, replies)
+
+          record
+        else
+          return {error: 'Title already in use!'}
+        end
       end
 
       def edit(user_id, reply_id, title, content)

--- a/plugin.rb
+++ b/plugin.rb
@@ -39,7 +39,7 @@ after_initialize do
 
         if (titleAlreadyUsed == false)
           id = SecureRandom.hex(16)
-          record = { id: id, title: title, content: content }
+          record = { status: 200, id: id, title: title, content: content }
 
           replies = PluginStore.get(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME) || {}
 
@@ -48,7 +48,7 @@ after_initialize do
 
           record
         else
-          return {error: 'Title already in use!'}
+          return {status: 500, error: 'Title already in use!'}
         end
       end
 
@@ -117,7 +117,12 @@ after_initialize do
       user_id = current_user.id
 
       record = CannedReply::Reply.add(user_id, title, content)
-      render json: record
+
+      if (record[:status] == 500)
+          render json: record, status: 500
+      else
+          render json: record
+      end
     end
 
     def destroy

--- a/plugin.rb
+++ b/plugin.rb
@@ -48,7 +48,7 @@ after_initialize do
 
           record
         else
-          return { status: 500, error: 'Title already in use!' }
+          { status: 500, error: 'Title already in use!' }
         end
       end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -48,7 +48,7 @@ after_initialize do
 
           record
         else
-          return {status: 500, error: 'Title already in use!'}
+          return { status: 500, error: 'Title already in use!' }
         end
       end
 


### PR DESCRIPTION
This pull request addresses the issue "Canned replies should require titles to be unique" discussed at https://meta.discourse.org/t/canned-replies-should-require-titles-to-be-unique/103996