### PR TITLE
Add Ability to Give Groups Access to Canned Replies

### DIFF
--- a/assets/javascripts/initializers/add-canned-replies-ui-builder.js.es6
+++ b/assets/javascripts/initializers/add-canned-replies-ui-builder.js.es6
@@ -34,11 +34,23 @@ export default {
   initialize(container) {
     const siteSettings = container.lookup("site-settings:main");
     const currentUser = container.lookup("current-user:main");
-
+    let currentUserGroupNames = [];
+    if (currentUser && currentUser.groups) {
+      currentUserGroupNames = currentUser.groups.map(group =>
+        group.name.toLowerCase()
+      );
+    }
+    const cannedRepliesGroups = siteSettings.canned_replies_groups
+      .split("|")
+      .filter(x => x)
+      .map(x => x.toLowerCase());
     if (
       siteSettings.canned_replies_enabled &&
       currentUser &&
-      currentUser.staff
+      (currentUser.staff ||
+        currentUserGroupNames.some(group =>
+          cannedRepliesGroups.includes(group)
+        ))
     ) {
       withPluginApi("0.5", initializeCannedRepliesUIBuilder);
     }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,6 +1,7 @@
 en:
   site_settings:
     canned_replies_enabled: 'Show insert canned reply button on composer window?'
+    canned_replies_groups: 'Add access to canned replies for non-staff groups by group name'
   replies:
     default_reply:
       title: "My first canned reply"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,3 +2,7 @@ plugins:
   canned_replies_enabled:
     default: true
     client: true
+  canned_replies_groups:
+    default: ""
+    client: true
+    type: list

--- a/test/javascripts/acceptance/canned-replies-test.js.es6
+++ b/test/javascripts/acceptance/canned-replies-test.js.es6
@@ -3,7 +3,10 @@ import { clearPopupMenuOptionsCallback } from "discourse/controllers/composer";
 
 acceptance("Canned Replies", {
   loggedIn: true,
-  settings: { canned_replies_enabled: true },
+  settings: {
+    canned_replies_enabled: true,
+    canned_replies_groups: "test_group"
+  },
   pretend(server, helper) {
     server.patch("/canned_replies/cd6680d7a04caaac1274e6f37429458c/use", () => {
       return helper.response({});


### PR DESCRIPTION
This PR implements the feature discussed briefly here: https://meta.discourse.org/t/discourse-canned-replies/48296/143

Basically, we've added a site setting that allows adding a list of group names who can have access to canned replies. Behavior defaults to staff having access automatically with the ability to add group access using the setting.

This required changes in two places: on the front-end initializer and the back-end routes (where we refactored to a custom constraint). Tests are in place and are passing as far as I could see.