### PR TITLE
FIX: Use top-level namespace for base classes

### DIFF
--- a/app/jobs/onceoff/rename_canned_replies.rb
+++ b/app/jobs/onceoff/rename_canned_replies.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class RenameCannedReplies < Jobs::Onceoff
+  class RenameCannedReplies < ::Jobs::Onceoff
     OLD_PLUGIN_NAME = "canned_replies"
     NEW_PLUGIN_NAME = "discourse-canned-replies"
 


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364