### PR TITLE
Fixing the SPDX code to match the project license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "author": "Discourse",
-  "license": "MIT",
+  "license": "GPL-2.0-only",
   "devDependencies": {
     "eslint-config-discourse": "^1.1.3"
   }


### PR DESCRIPTION
I noticed that the package.json stated MIT rather than GPL 2.0.