### PR TITLE
UX: hide hyperlink and calendar buttons in d-editor.

### DIFF
--- a/assets/stylesheets/canned-replies.scss
+++ b/assets/stylesheets/canned-replies.scss
@@ -13,7 +13,8 @@
     margin-top: 10px;
   }
 
-  .btn.link, .btn.local-dates {
+  .btn.link,
+  .btn.local-dates {
     display: none;
   }
 }

--- a/assets/stylesheets/canned-replies.scss
+++ b/assets/stylesheets/canned-replies.scss
@@ -12,6 +12,10 @@
   .content {
     margin-top: 10px;
   }
+
+  .btn.link, .btn.local-dates {
+    display: none;
+  }
 }
 
 .mobile-view .canned-replies-modal {


### PR DESCRIPTION
Here we're preventing the render of nested/multiple modal windows.

It fixes the issue reported in https://meta.discourse.org/t/cant-insert-hyperlinks-into-canned-replies/169508