### PR TITLE
FIX: Guardians to ensure correct permissions

### DIFF
--- a/assets/javascripts/controllers/canned-replies.js.es6
+++ b/assets/javascripts/controllers/canned-replies.js.es6
@@ -9,9 +9,21 @@ export default Ember.Controller.extend(ModalFunctionality, {
   selectedReply: null,
   selectedReplyId: "",
   loadingReplies: true,
+  canEdit: false,
 
   init() {
     this._super(...arguments);
+
+    const currentUser = this.get("currentUser");
+    const everyoneCanEdit =
+      this.get("siteSettings.canned_replies_everyone_enabled") &&
+      this.get("siteSettings.canned_replies_everyone_can_edit");
+    const currentUserCanEdit =
+      this.get("siteSettings.canned_replies_enabled") &&
+      currentUser &&
+      currentUser.can_edit_canned_replies;
+    const canEdit = currentUserCanEdit ? currentUserCanEdit : everyoneCanEdit;
+    this.set("canEdit", canEdit);
 
     this.replies = [];
   },

--- a/assets/javascripts/controllers/canned-replies.js.es6
+++ b/assets/javascripts/controllers/canned-replies.js.es6
@@ -16,10 +16,10 @@ export default Ember.Controller.extend(ModalFunctionality, {
 
     const currentUser = this.get("currentUser");
     const everyoneCanEdit =
-      this.get("siteSettings.canned_replies_everyone_enabled") &&
-      this.get("siteSettings.canned_replies_everyone_can_edit");
+      this.siteSettings.canned_replies_everyone_enabled &&
+      this.siteSettings.canned_replies_everyone_can_edit;
     const currentUserCanEdit =
-      this.get("siteSettings.canned_replies_enabled") &&
+      this.siteSettings.canned_replies_enabled &&
       currentUser &&
       currentUser.can_edit_canned_replies;
     const canEdit = currentUserCanEdit ? currentUserCanEdit : everyoneCanEdit;

--- a/assets/javascripts/discourse/templates/modal/canned-replies.hbs
+++ b/assets/javascripts/discourse/templates/modal/canned-replies.hbs
@@ -28,20 +28,24 @@
 {{/d-modal-body}}
 
 <div class="modal-footer">
-  {{d-button
-    class="pull-left canned-replies-new"
-    action=(action "newReply")
-    icon="plus"
-    label="canned_replies.insert.new_button"
-  }}
+  {{#if canEdit}}
+    {{d-button
+      class="pull-left canned-replies-new"
+      action=(action "newReply")
+      icon="plus"
+      label="canned_replies.insert.new_button"
+    }}
+  {{/if}}
 
   {{#if selectedReply}}
-    {{d-button
-      class="pull-left canned-replies-edit"
-      action=(action "editReply")
-      icon="pencil-alt"
-      label="canned_replies.insert.edit_button"
-    }}
+    {{#if canEdit}}
+      {{d-button
+        class="pull-left canned-replies-edit"
+        action=(action "editReply")
+        icon="pencil-alt"
+        label="canned_replies.insert.edit_button"
+      }}
+    {{/if}}
 
     {{d-button
       class="btn-primary pull-right canned-replies-apply"

--- a/plugin.rb
+++ b/plugin.rb
@@ -98,9 +98,16 @@ after_initialize do
     requires_plugin CannedReply::PLUGIN_NAME
 
     before_action :ensure_logged_in
+    before_action :ensure_canned_replies_enabled
     skip_before_action :check_xhr
 
+    def ensure_canned_replies_enabled
+      guardian.ensure_can_use_canned_replies!
+    end
+
     def create
+      guardian.ensure_can_edit_canned_replies!
+
       title   = params.require(:title)
       content = params.require(:content)
       user_id = current_user.id
@@ -110,6 +117,8 @@ after_initialize do
     end
 
     def destroy
+      guardian.ensure_can_edit_canned_replies!
+
       reply_id = params.require(:id)
       user_id  = current_user.id
       record = CannedReply::Reply.remove(user_id, reply_id)
@@ -126,6 +135,8 @@ after_initialize do
     end
 
     def update
+      guardian.ensure_can_edit_canned_replies!
+
       reply_id = params.require(:id)
       title = params.require(:title)
       content = params.require(:content)
@@ -165,26 +176,20 @@ after_initialize do
     groups.any? { |group| group_list.include?(group.name.downcase) }
   end
 
+  add_to_class(:guardian, :can_edit_canned_replies?) do
+     user && user.can_edit_canned_replies?
+   end
+
+   add_to_class(:guardian, :can_use_canned_replies?) do
+     user && user.can_use_canned_replies?
+   end
+
   add_to_serializer(:current_user, :can_use_canned_replies) do
     object.can_use_canned_replies?
   end
 
   add_to_serializer(:current_user, :can_edit_canned_replies) do
     object.can_edit_canned_replies?
-  end
-
-  require_dependency 'current_user'
-  class CannedRepliesConstraint
-    def matches?(request)
-      provider = Discourse.current_user_provider.new(request.env)
-      if request.get? || (request.patch? && request.path[-4..-1] == '/use')
-        provider.current_user&.can_use_canned_replies?
-      else
-        provider.current_user&.can_edit_canned_replies?
-      end
-    rescue Discourse::InvalidAccess, Discourse::ReadOnly
-      false
-    end
   end
 
   CannedReply::Engine.routes.draw do
@@ -197,7 +202,7 @@ after_initialize do
   end
 
   Discourse::Application.routes.append do
-    mount ::CannedReply::Engine, at: "/canned_replies", constraints: CannedRepliesConstraint.new
+    mount ::CannedReply::Engine, at: "/canned_replies"
   end
 
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -177,8 +177,8 @@ after_initialize do
   end
 
   add_to_class(:guardian, :can_edit_canned_replies?) do
-     user && user.can_edit_canned_replies?
-   end
+    user && user.can_edit_canned_replies?
+  end
 
   add_to_class(:guardian, :can_use_canned_replies?) do
     user && user.can_use_canned_replies?

--- a/plugin.rb
+++ b/plugin.rb
@@ -180,9 +180,9 @@ after_initialize do
      user && user.can_edit_canned_replies?
    end
 
-   add_to_class(:guardian, :can_use_canned_replies?) do
-     user && user.can_use_canned_replies?
-   end
+  add_to_class(:guardian, :can_use_canned_replies?) do
+    user && user.can_use_canned_replies?
+  end
 
   add_to_serializer(:current_user, :can_use_canned_replies) do
     object.can_use_canned_replies?

--- a/spec/integration/canned_reply/canned_replies_spec.rb
+++ b/spec/integration/canned_reply/canned_replies_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CannedReply::CannedRepliesController do
         user
 
         get '/canned_replies'
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
     end
 
@@ -97,7 +97,7 @@ RSpec.describe CannedReply::CannedRepliesController do
         user
 
         delete '/canned_replies/someid'
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
 
       it 'should raise the right error with everyone enabled' do
@@ -105,7 +105,7 @@ RSpec.describe CannedReply::CannedRepliesController do
         user
 
         delete '/canned_replies/someid'
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
     end
 
@@ -161,14 +161,14 @@ RSpec.describe CannedReply::CannedRepliesController do
         user
 
         put '/canned_replies/someid'
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
       it 'should raise the right error with everyone enabled' do
         SiteSetting.canned_replies_everyone_enabled = true
         user
 
         put '/canned_replies/someid'
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
     end
 
@@ -206,7 +206,7 @@ RSpec.describe CannedReply::CannedRepliesController do
           title: 'new title', content: 'new content'
         }
 
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
 
       it 'should be able to edit a reply when SiteSetting is enabled' do
@@ -262,7 +262,7 @@ RSpec.describe CannedReply::CannedRepliesController do
         user
 
         patch "/canned_replies/#{canned_reply[:id]}/use"
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
 
       it 'should be able to record a user with everyone enabled' do
@@ -298,7 +298,7 @@ RSpec.describe CannedReply::CannedRepliesController do
         user
 
         get "/canned_replies/#{canned_reply[:id]}/reply"
-        expect(response.status).to eq(404)
+        expect(response.status).to eq(403)
       end
       it 'should succeed with everyone enabled' do
         SiteSetting.canned_replies_everyone_enabled = true

--- a/spec/integration/canned_reply/canned_replies_spec.rb
+++ b/spec/integration/canned_reply/canned_replies_spec.rb
@@ -181,7 +181,7 @@ RSpec.describe CannedReply::CannedRepliesController do
 
       id, _new_reply = PluginStore.get(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME).first
 
-      put "/canned_replies/#{id}", params: {
+      patch "/canned_replies/#{id}", params: {
         title: 'new title', content: 'new content'
       }
 
@@ -191,6 +191,38 @@ RSpec.describe CannedReply::CannedRepliesController do
 
       expect(reply["title"]).to eq('new title')
       expect(reply["content"]).to eq('new content')
+    end
+
+    context 'as a normal user' do
+      before do
+        SiteSetting.canned_replies_everyone_enabled = true
+
+        canned_reply
+        user
+      end
+
+      it 'should not be able to edit a reply' do
+        patch "/canned_replies/#{canned_reply[:id]}", params: {
+          title: 'new title', content: 'new content'
+        }
+
+        expect(response.status).to eq(404)
+      end
+
+      it 'should be able to edit a reply when SiteSetting is enabled' do
+        SiteSetting.canned_replies_everyone_can_edit = true
+
+        patch "/canned_replies/#{canned_reply[:id]}", params: {
+          title: 'new title', content: 'new content'
+        }
+
+        expect(response).to be_successful
+
+        id, reply = PluginStore.get(CannedReply::PLUGIN_NAME, CannedReply::STORE_NAME).first
+
+        expect(reply["title"]).to eq('new title')
+        expect(reply["content"]).to eq('new content')
+      end
     end
 
     context 'as a staff' do


### PR DESCRIPTION
Add guardians to ensure the user can use/edit canned replies.

Also try to hide options on the UI that aren’t available to the user.