### PR TITLE
DEV: apply ember-template-lint fixes

### DIFF
--- a/assets/javascripts/components/canned-reply.js.es6
+++ b/assets/javascripts/components/canned-reply.js.es6
@@ -2,7 +2,6 @@ import showModal from "discourse/lib/show-modal";
 import applyReply from "discourse/plugins/discourse-canned-replies/lib/apply-reply";
 
 export default Ember.Component.extend({
-  isOpen: false,
   canEdit: false,
 
   init() {
@@ -20,10 +19,6 @@ export default Ember.Component.extend({
   },
 
   actions: {
-    toggle() {
-      this.toggleProperty("isOpen");
-    },
-
     apply() {
       const composer = Discourse.__container__.lookup("controller:composer");
 

--- a/assets/javascripts/discourse/templates/components/canned-reply.hbs
+++ b/assets/javascripts/discourse/templates/components/canned-reply.hbs
@@ -1,25 +1,25 @@
-<div class="canned-reply" id="canned-reply-{{reply.id}}">
-  <div {{action "toggle"}} class="canned-reply-title">
-    {{d-button
-      class="canned-replies-apply"
-      action=(action "apply")
-      icon="far-clipboard"
-    }}
+<details class="canned-reply" id="canned-reply-{{reply.id}}">
+  <summary class="canned-reply-title">
+    <div class="canned-reply-title-text">{{reply.title}}</div>
 
-    {{#if canEdit}}
+    <div class="actions">
       {{d-button
-        class="canned-replies-edit"
-        action=(action "editReply")
-        icon="pencil-alt"
+        class="canned-replies-apply"
+        action=(action "apply")
+        icon="far-clipboard"
       }}
-    {{/if}}
 
-    <div class="canned-replies-title-text">{{reply.title}}</div>
-  </div>
-
-  {{#if isOpen}}
-    <div class="canned-replies-content">
-      {{{cook-text reply.content}}}
+      {{#if canEdit}}
+        {{d-button
+          class="canned-replies-edit"
+          action=(action "editReply")
+          icon="pencil-alt"
+        }}
+      {{/if}}
     </div>
-  {{/if}}
-</div>
+  </summary>
+
+  <div class="canned-replies-content">
+    {{cook-text reply.content}}
+  </div>
+</details>

--- a/assets/javascripts/discourse/templates/modal/canned-replies.hbs
+++ b/assets/javascripts/discourse/templates/modal/canned-replies.hbs
@@ -20,7 +20,7 @@
 
       {{#if selectedReply}}
         <div class="content">
-          <div>{{{cook-text selectedReply.content}}}</div>
+          <div>{{cook-text selectedReply.content}}</div>
         </div>
       {{/if}}
     </div>

--- a/assets/javascripts/discourse/templates/modal/edit-reply.hbs
+++ b/assets/javascripts/discourse/templates/modal/edit-reply.hbs
@@ -4,19 +4,22 @@
 
 <div class="modal-footer canned-replies-footer">
   {{d-button class="btn-primary edit-reply-save-btn"
-      action=(action "save")
-      label=savingLabel
-      disabled=disableSaveButton}}
+    action=(action "save")
+    label=savingLabel
+    disabled=disableSaveButton
+  }}
 
-      {{d-button 
-      action=(action "cancel")
-      icon="chevron-left"
-      label="canned_replies.back"
-      class="canned-replies-edit-back"
-      }}
+  {{d-button
+    action=(action "cancel")
+    icon="chevron-left"
+    label="canned_replies.back"
+    class="canned-replies-edit-back"
+  }}
 
-  {{d-button class="btn-danger"
-      action=(action "remove")
-      icon="trash-alt"
-      disabled=saving}}
+  {{d-button
+    class="btn-danger"
+    action=(action "remove")
+    icon="trash-alt"
+    disabled=saving
+  }}
 </div>

--- a/assets/stylesheets/canned-replies.scss
+++ b/assets/stylesheets/canned-replies.scss
@@ -41,7 +41,7 @@
   display: flex;
   align-items: center;
   button {
-    margin-right: 0.5em;
+    margin-left: 0.5em;
   }
 
   &:hover {
@@ -50,7 +50,7 @@
   }
 }
 
-.canned-replies-title-text {
+.canned-reply-title-text {
   font-weight: bold;
   margin-left: 0.5em;
   @include ellipsis;
@@ -64,6 +64,19 @@
 
   .canned-reply {
     padding-bottom: 1em;
+
+    .canned-reply-title {
+      display: flex;
+      align-items: center;
+
+      .canned-reply-title-text {
+        max-width: 75%;
+      }
+
+      .actions {
+        margin-left: auto;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Note: as part of a change to not use non interactive element, the list of canned replies is now using summary/details for collapsing.