### PR TITLE
DEV: Fix JS tests to use default site settings

### DIFF
--- a/test/javascripts/acceptance/canned-replies-test.js
+++ b/test/javascripts/acceptance/canned-replies-test.js
@@ -83,6 +83,9 @@ acceptance("Canned Replies", function (needs) {
     await visit("/");
 
     await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
     await fillIn(".d-editor-input", "beforeafter");
 
     const editorInput = $(".d-editor-input")[0];
@@ -171,6 +174,9 @@ acceptance("Canned Replies", function (needs) {
     await visit("/");
 
     await click("#create-topic");
+    const categoryChooser = selectKit(".category-chooser");
+    await categoryChooser.expand();
+    await categoryChooser.selectRowByValue(2);
     await popUpMenu.expand();
     await popUpMenu.selectRowByValue("showCannedRepliesButton");
 


### PR DESCRIPTION
In preparation for core PR https://github.com/discourse/discourse/pull/18413 which changes JS to load default yml site settings, the main one needing changes is that now the
allow_uncategorized_topics setting is false
by default, which requires setting the category
in the composer before using it.