### PR TITLE
DEV: Update plugin to match latest guidelines

### DIFF
--- a/app/controllers/discourse_canned_replies/canned_replies_controller.rb
+++ b/app/controllers/discourse_canned_replies/canned_replies_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module DiscourseCannedReplies
+module ::DiscourseCannedReplies
   class CannedRepliesController < ::ApplicationController
     requires_plugin DiscourseCannedReplies::PLUGIN_NAME
     before_action :ensure_logged_in

--- a/app/models/discourse_canned_replies/reply.rb
+++ b/app/models/discourse_canned_replies/reply.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module DiscourseCannedReplies
+module ::DiscourseCannedReplies
   class Reply
     def self.add(user_id, title, content)
       id = SecureRandom.hex(16)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+DiscourseCannedReplies::Engine.routes.draw do
+  resources :canned_replies, path: "/", only: %i[index create destroy update] do
+    member do
+      get "reply"
+      patch "use"
+    end
+  end
+end
+
+Discourse::Application.routes.append do
+  mount ::DiscourseCannedReplies::Engine, at: "/canned_replies"
+end

--- a/lib/discourse_canned_replies/engine.rb
+++ b/lib/discourse_canned_replies/engine.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module ::DiscourseCannedReplies
+  class Engine < ::Rails::Engine
+    engine_name PLUGIN_NAME
+    isolate_namespace DiscourseCannedReplies
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -13,33 +13,15 @@ register_asset "stylesheets/canned-replies.scss"
 
 register_svg_icon "far-clipboard" if respond_to?(:register_svg_icon)
 
+module ::DiscourseCannedReplies
+  PLUGIN_NAME = "discourse-canned-replies"
+  STORE_NAME = "replies"
+end
+
+require_relative "lib/discourse_canned_replies/engine"
+
 after_initialize do
-  module ::DiscourseCannedReplies
-    PLUGIN_NAME = "discourse-canned-replies"
-    STORE_NAME = "replies"
-
-    class Engine < ::Rails::Engine
-      engine_name DiscourseCannedReplies::PLUGIN_NAME
-      isolate_namespace DiscourseCannedReplies
-    end
-  end
-
-  require_relative "app/controllers/discourse_canned_replies/canned_replies_controller.rb"
   require_relative "app/jobs/onceoff/rename_canned_replies.rb"
-  require_relative "app/models/discourse_canned_replies/reply.rb"
-
-  DiscourseCannedReplies::Engine.routes.draw do
-    resources :canned_replies, path: "/", only: %i[index create destroy update] do
-      member do
-        get "reply"
-        patch "use"
-      end
-    end
-  end
-
-  Discourse::Application.routes.append do
-    mount ::DiscourseCannedReplies::Engine, at: "/canned_replies"
-  end
 
   add_to_class(:user, :can_edit_canned_replies?) do
     return true if staff?


### PR DESCRIPTION
This commit updates the plugin to follow the latest guidelines, as shown in discourse-plugin-skeleton, removing the explicit require calls and using config/routes.rb for defining all routes.