### PR TITLE
DEV: Fix Zeitwerk reloading error (#249)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,4 @@ DiscourseCannedReplies::Engine.routes.draw do
   end
 end
 
-Discourse::Application.routes.append do
-  mount ::DiscourseCannedReplies::Engine, at: "/canned_replies"
-end
+Discourse::Application.routes.draw { mount ::DiscourseCannedReplies::Engine, at: "/canned_replies" }


### PR DESCRIPTION
Using `.append` can lead to a 'two routes with the same name' error

Reproduced via

```
rails runner 'Rails.application.reloader.reload!'
```